### PR TITLE
Allow for new collections, multiple arguments in let

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,4 +133,35 @@ end
 	@test x == 1
 end
 
+@testset "new dict" begin
+	d = @addto! Dict() begin
+		x = 1
+		@add y = 2
+	end
+
+	@test d == Dict{Any, Any}(:y => 2)
+
+	d = @addto! Dict() let
+		x = 10
+		@add y = 20
+	end
+
+	@test d == Dict{Any, Any}(:y => 20)
+
+
+	d = @addto! Dict() let z = 50
+		x = 100
+		@add y = 200
+	end
+
+	@test d == Dict{Any, Any}(:y => 200)
+
+	d = @addto! Dict() let z = 50, zz = 51
+		x = 100
+		@add y = 200
+	end
+
+	@test d == Dict{Any, Any}(:y => 200)
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,6 +131,22 @@ end
 
 	@test res == Dict([:y => 5])
 	@test x == 1
+
+	@addto! res let z = 1
+		local x = 2
+		@add y = 5
+	end
+
+	@test res == Dict([:y => 5])
+	@test x == 1
+
+	@addto! res let z = 1, z1 = 2
+		local x = 2
+		@add y = 5
+	end
+
+	@test res == Dict([:y => 5])
+	@test x == 1
 end
 
 @testset "new dict" begin


### PR DESCRIPTION
Fixed #5 

Also fixes some bugs with allowing `let` with multiple assignments at the beginning. 